### PR TITLE
Whitesource scanning fix

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,6 @@
 {
   "scanSettings": {
-    "configMode": "AUTO",
+    "configMode": "LOCAL",
     "configExternalURL": "",
     "projectToken": "",
     "baseBranches": []
@@ -12,4 +12,4 @@
   "issueSettings": {
     "minSeverityLevel": "LOW"
   }
-}
+} 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Distributed under the Apache License, Version 2.0.
 
 SPDX-License-Identifier: Apache-2.0
 
-# Vulnerabilities
+# Vulnerabilities / Security
 
-If you uncover vulnerabilities in this software, please contact `help@finos.org` privately 
+Please see our [Security Policy](SECURITY.md).
 
 # For Maintainers
 
@@ -143,11 +143,15 @@ mvn versions:set -DnewVersion=<our breaking change no>.<symphony-api-version>.<o
 # then push to git (spring-bot-develop branch)
 ```
 
-3.  On `oss.sonatype.org`
+3. SECURITY.md
+
+- Update this with new version numbers if needed.
+
+4.  On `oss.sonatype.org`
 
 - Close the Staging Repository
 - Release it.
 
-4.  Perform release on github with same number
+5.  Perform release on github with same number
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 8.x.x   | :white_check_mark: |
+| 9.x.x   | :x:                |
+| < 8.0.0 | :x:                |
+
+## Reporting a Vulnerability
+
+If you uncover vulnerabilities in this software, please contact `help@finos.org` privately.  We aim to respond within 3 working days.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ currently being supported with security updates.
 | Version | Supported          |
 | ------- | ------------------ |
 | 8.x.x   | :white_check_mark: |
-| 9.x.x   | :x:                |
+| 9.x.x   | :white_check_mark: |
 | < 8.0.0 | :x:                |
 
 ## Reporting a Vulnerability

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,0 +1,15 @@
+resolveAllDependencies=false
+
+maven.runPreStep=true
+maven.resolveDependencies=true
+maven.ignoredScopes=[]
+maven.ignoreSourceFiles=true
+maven.ignorePomModules=true
+maven.ignoreMvnTreeErrors=true
+maven.aggregateModules=false
+#maven.projectNameFromDependencyFile=false
+#maven.maxCacheFolderSize=
+#maven.m2RepositoryPath=
+#maven.environmentPath=
+#maven.downloadMissingDependencies=true
+#maven.additionalArguments=


### PR DESCRIPTION
This is a suggestion from Whitesource in response to this https://whitesourcesoftware.force.com/SupportPortal/s/case/5005p00002h2qKeAAI/spring-bot-project

```
Hi Rob,

I hope you are doing well! Thank you for allowing me the time to review this.

Regarding the option to see the source of the files, we have an open feature request to provide this, please let me know if you would like me to add you as a requestor.

Regarding this project, I was indeed able to build the project successfully now, and I did some testing including cloning and scanning the project locally and forking and using the WhiteSource GitHub integration.
The issue here stems from the fact that WhiteSource is scanning the project before it is built which results in missing dependencies.

In order to make sure that WhiteSource has all the dependencies available during the scan, we can add a step that would have WhiteSource build the project.

This can be achieved by changing the scan configuration and enabling the Maven pre-step.
To do that, please perform the following steps:
1. Create a whitesource.config file either in the repo or in an external location and make sure it is accessible from your repo. This file will be used to change the scan configuration.
2. This file should contain all the settings that are required for the scan, you can use the attached file I added to this case. The reason for adding all these additional settings and not just the maven.runPreStep=true parameter is that once we change any scan settings, the configuration defaults to the settings of the unified agent, which are not the most suited for the repo scan.
3. Navigate to the .whitesource file in your repo and change the "configMode" to be either “LOCAL” or "EXTERNAL" based on where you selected to place the whitesource.config file. If you choose "EXTERNAL" set the “configExternalURL” to point to the file you created.
For more information about the external/local configuration, refer here: https://whitesource.atlassian.net/wiki/spaces/WD/pages/697696422/WhiteSource+for+GitHub.com#Scan-Settings-(scanSettings)

Feel free to review this forked repo for the expected result: https://github.com/Gal-Doron/spring-bot

I hope you find this useful, please let me know if you have any questions.

Best,
Gal
```

It should fix our white source scanning