### PR TITLE
Override MimePull lib version

### DIFF
--- a/demos/demo-bot/pom.xml
+++ b/demos/demo-bot/pom.xml
@@ -8,7 +8,7 @@
 		<groupId>org.finos.springbot</groupId>
 		<artifactId>spring-bot</artifactId>
 		<version>9.0.1-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>org.finos.springbot.demos</groupId>

--- a/demos/rooms-bot/pom.xml
+++ b/demos/rooms-bot/pom.xml
@@ -7,7 +7,7 @@
 		<groupId>org.finos.springbot</groupId>
 		<artifactId>spring-bot</artifactId>
 		<version>9.0.1-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
 	<groupId>org.finos.springbot.demos</groupId>

--- a/libs/teams/teams-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/teams/TeamsWorkflowConfig.java
+++ b/libs/teams/teams-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/teams/TeamsWorkflowConfig.java
@@ -158,7 +158,7 @@ public class TeamsWorkflowConfig {
 	@Bean
 	@ConditionalOnProperty(matchIfMissing = true, name = "teams.storage.type", havingValue = "memory")
 	@ConditionalOnMissingBean
-	public TeamsStateStorage teamsAzureBlobStateStorage() {
+	public TeamsStateStorage teamsInMemoryStateStorage() {
 		LOG.warn("Using Memory storage for Azure data - NOT FOR PRODUCTION");
 		return new MemoryStateStorage();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 		<jsoup.version>1.14.3</jsoup.version>
 		<graalvm.version>21.2.0</graalvm.version>
 		<symphony-bdk.version>2.5.0</symphony-bdk.version>
+		<mimepull.version>1.9.15</mimepull.version>
 	</properties>
 
 	<licenses>
@@ -211,6 +212,13 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- SpringBoot 2.7.0 pulls 1.10 version of below lib which is compiled with Java11 and hence causes errors -->
+			<dependency>
+				<groupId>org.jvnet.mimepull</groupId>
+				<artifactId>mimepull</artifactId>
+				<version>${mimepull.version}</version>
+			</dependency>
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>


### PR DESCRIPTION
SpringBoot 2.7.0 pulls 1.10 version of below lib which is compiled with Java11 and hence causes errors when running on Java8