### PR TITLE
Stanford nlp scope

### DIFF
--- a/.github/workflows/acceptable-licenses.txt
+++ b/.github/workflows/acceptable-licenses.txt
@@ -47,3 +47,4 @@
 <name>W3C license</name>
 <name>jQuery license</name>
 <name>MIT</name>
+<name>MIT-0</name>

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -37,11 +37,12 @@ jobs:
     - name: Build 
       run: mvn install -DskipTests
     - name: License XML report
-      run: mvn org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses
+      run: |
+        mvn org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses -Dlicense.excludedScopes=system,provided -DlicensesConfigFile=.github/workflows/licenses-config-file.xml
     - name: Validate XML report
       run: |
         ALLOW_LICENSES=`cat .github/workflows/acceptable-licenses.txt | sed "s|<name>|name='|" | sed "s|</name>|' |" | tr -s '\n' '~' | sed 's/\~/or /g' `
-        find . -name licenses.xml -exec  xq "//dependency[count(licenses/license[${ALLOW_LICENSES}])=0]" {} \; > target/license-issues.xml       
+        find . -name licenses.xml -exec  xq "//dependency[count(licenses/license[${ALLOW_LICENSES}])=0]" {} \; > target/license-issues.xml
         LINES_FOUND=`cat target/license-issues.xml | grep "<result>" | wc -l`
         if [ $LINES_FOUND -gt 0 ]; then cat target/license-issues.xml ; exit -1; fi
     - name: Upload license XML Issues

--- a/.github/workflows/licenses-config-file.xml
+++ b/.github/workflows/licenses-config-file.xml
@@ -1,0 +1,18 @@
+<!-- Checkout docs on https://www.mojohaus.org/license-maven-plugin/download-licenses-mojo.html#licensesConfigFile -->
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>\Qorg.openapitool\E</groupId>
+      <artifactId>\Qjackson-databind-nullable\E</artifactId>
+      <matchLicenses>
+        <!-- Match an empty list of licenses -->
+      </matchLicenses>
+      <licenses>
+        <license>
+          <name>Apache 2.0</name>
+          <url>https://github.com/OpenAPITools/jackson-databind-nullable/blob/master/LICENSE</url>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/tools/reminder-bot/pom.xml
+++ b/tools/reminder-bot/pom.xml
@@ -54,6 +54,7 @@
 			<groupId>edu.washington.cs.knowitall.stanford-corenlp</groupId>
 			<artifactId>stanford-sutime-models</artifactId>
 			<version>${sutime-models.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/tools/reminder-bot/pom.xml
+++ b/tools/reminder-bot/pom.xml
@@ -40,12 +40,14 @@
 			<groupId>edu.stanford.nlp</groupId>
 			<artifactId>stanford-corenlp</artifactId>
 			<version>${corenlp.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>edu.stanford.nlp</groupId>
 			<artifactId>stanford-corenlp</artifactId>
 			<version>${corenlp.version}</version>
 			<classifier>models</classifier>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The license scan does not include the Stanford dependencies, as they are mark as provided.

However, there is one dependency, `jackson-databind-nullable` that does not include license info. I've followed https://www.mojohaus.org/license-maven-plugin/download-licenses-mojo.html#licensesConfigFile to solve it, but it seems that it's not working.

Maybe you could have a look when you got time and see if you can find out what's going on?