### PR TITLE
fix(symphony): fix class and method name typos in SymphonyDataHandlerConfig

### DIFF
--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/symphony/SymphonyWorkflowConfig.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/symphony/SymphonyWorkflowConfig.java
@@ -12,7 +12,7 @@ import org.finos.springbot.symphony.conversations.RoomMembershipChangeHandler;
 import org.finos.springbot.symphony.conversations.StreamResolver;
 import org.finos.springbot.symphony.conversations.SymphonyConversations;
 import org.finos.springbot.symphony.conversations.SymphonyConversationsImpl;
-import org.finos.springbot.symphony.data.SymphonyDataHandlerCofig;
+import org.finos.springbot.symphony.data.SymphonyDataHandlerConfig;
 import org.finos.springbot.symphony.form.ElementsHandler;
 import org.finos.springbot.symphony.form.SymphonyFormConverter;
 import org.finos.springbot.symphony.form.SymphonyFormDeserializerModule;
@@ -65,7 +65,7 @@ import com.symphony.bdk.spring.SymphonyBdkAutoConfiguration;
 	ChatWorkflowConfig.class, 
 	FreemarkerTypeConverterConfig.class, 
 	SymphonyContentConfig.class,
-	SymphonyDataHandlerCofig.class})
+	SymphonyDataHandlerConfig.class})
 @Profile(value = "symphony")
 public class SymphonyWorkflowConfig {
 	

--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/symphony/data/SymphonyDataHandlerConfig.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/main/java/org/finos/springbot/symphony/data/SymphonyDataHandlerConfig.java
@@ -18,7 +18,7 @@ import com.symphony.user.StreamID;
 
 @Configuration
 @Import(DataHandlerConfig.class)
-public class SymphonyDataHandlerCofig implements InitializingBean {
+public class SymphonyDataHandlerConfig implements InitializingBean {
 
 	
 	@Autowired
@@ -30,14 +30,14 @@ public class SymphonyDataHandlerCofig implements InitializingBean {
 		VersionSpaceHelp.basicSymphonyVersionSpace().stream()
 			.forEach(vs -> ejc.addVersionSpace(vs));
 		
-		List<VersionSpace> chatWorkflowVersionSpaces = syphonyExtendedVersionSpace();
+		List<VersionSpace> chatWorkflowVersionSpaces = symphonyExtendedVersionSpace();
 		
 		chatWorkflowVersionSpaces.stream().forEach(vs -> ejc.addVersionSpace(vs));
 		
 		ejc.getObjectMapper().registerModule(new LegacyFormatModule());
 	}
 
-	public static List<VersionSpace> syphonyExtendedVersionSpace() {
+	public static List<VersionSpace> symphonyExtendedVersionSpace() {
 		return Arrays.asList(			
 				new VersionSpace(DisplayName.class, "1.0"), 
 				new VersionSpace(StreamID.class, "1.0"), 

--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/content/TestMessageMLParser.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/content/TestMessageMLParser.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import org.finos.springbot.entityjson.EntityJson;
 import org.finos.springbot.symphony.SymphonyMockConfiguration;
 import org.finos.springbot.symphony.content.serialization.MessageMLParser;
-import org.finos.springbot.symphony.data.SymphonyDataHandlerCofig;
+import org.finos.springbot.symphony.data.SymphonyDataHandlerConfig;
 import org.finos.springbot.workflow.annotations.ChatVariable;
 import org.finos.springbot.workflow.content.Content;
 import org.finos.springbot.workflow.content.Message;
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest(classes = { 
 	SymphonyMockConfiguration.class, 
 	SymphonyContentConfig.class,
-	SymphonyDataHandlerCofig.class})
+	SymphonyDataHandlerConfig.class})
 public class TestMessageMLParser  {
 
 	@Autowired

--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/json/TestEntityJsonConversion.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/json/TestEntityJsonConversion.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import org.finos.springbot.entityjson.EntityJson;
 import org.finos.springbot.symphony.content.SymphonyRoom;
 import org.finos.springbot.symphony.content.SymphonyUser;
-import org.finos.springbot.symphony.data.SymphonyDataHandlerCofig;
+import org.finos.springbot.symphony.data.SymphonyDataHandlerConfig;
 import org.finos.springbot.workflow.data.EntityJsonConverter;
 import org.finos.springbot.workflow.tags.HeaderDetails;
 import org.junit.jupiter.api.Assertions;
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = { 
-		SymphonyDataHandlerCofig.class, 
+		SymphonyDataHandlerConfig.class, 
 })
 public class TestEntityJsonConversion {
 	

--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/json/TestSerialization.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/json/TestSerialization.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 import org.finos.springbot.entityjson.EntityJson;
 import org.finos.springbot.entityjson.VersionSpace;
-import org.finos.springbot.symphony.data.SymphonyDataHandlerCofig;
+import org.finos.springbot.symphony.data.SymphonyDataHandlerConfig;
 import org.finos.springbot.symphony.json.ClassWithArray.SubClass;
 import org.finos.springbot.workflow.data.EntityJsonConverter;
 import org.junit.jupiter.api.Assertions;
@@ -39,7 +39,7 @@ import com.symphony.integration.jira.event.v2.State;
 import com.symphony.user.Mention;
 
 @SpringBootTest(classes = { 
-		SymphonyDataHandlerCofig.class, 
+		SymphonyDataHandlerConfig.class, 
 })
 public class TestSerialization {
 	

--- a/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/templating/SymphonyTemplatingTest.java
+++ b/libs/symphony-bdk/symphony-bdk-chat-workflow-spring-boot-starter/src/test/java/org/finos/springbot/symphony/templating/SymphonyTemplatingTest.java
@@ -12,7 +12,7 @@ import java.util.stream.IntStream;
 
 import org.finos.springbot.symphony.content.SymphonyRoom;
 import org.finos.springbot.symphony.content.SymphonyUser;
-import org.finos.springbot.symphony.data.SymphonyDataHandlerCofig;
+import org.finos.springbot.symphony.data.SymphonyDataHandlerConfig;
 import org.finos.springbot.tests.templating.AbstractTemplatingTest;
 import org.finos.springbot.workflow.annotations.WorkMode;
 import org.finos.springbot.workflow.content.Addressable;
@@ -33,7 +33,7 @@ import org.springframework.util.StreamUtils;
 
 @SpringBootTest(classes = { 
 		FreemarkerTypeConverterConfig.class,
-		SymphonyDataHandlerCofig.class,
+		SymphonyDataHandlerConfig.class,
 })
 public class SymphonyTemplatingTest extends AbstractTemplatingTest {
 


### PR DESCRIPTION
Fixes #495.

### Summary
Fixes class and method name typos in the Symphony data handler Spring configuration:
- Renames `SymphonyDataHandlerCofig.java` -> `SymphonyDataHandlerConfig.java`
- Renames public class `SymphonyDataHandlerCofig` -> `SymphonyDataHandlerConfig`
- Renames helper method `syphonyExtendedVersionSpace()` -> `symphonyExtendedVersionSpace()`

### Impact
Updates `@Import` in `SymphonyWorkflowConfig.java` and `@ContextConfiguration` in all associated test classes (`SymphonyTemplatingTest`, `TestEntityJsonConversion`, `TestSerialization`, `TestMessageMLParser`).
